### PR TITLE
6章29節のRコード（2020年2月に再実行）

### DIFF
--- a/Chapter06.R
+++ b/Chapter06.R
@@ -30,7 +30,10 @@ df.pop.forecast <-
 head(df.pop.forecast)
 
 library(tidyr)
-df.pop.forecast %<>% gather(year, value, -Ward)
+df.pop.forecast %<>%
+  tidyr::pivot_longer(cols = -1,
+                      names_to = "year",
+                      values_to = "value")
 head(df.pop.forecast)
 
 library(ggplot2)

--- a/Chapter06.R
+++ b/Chapter06.R
@@ -1,4 +1,66 @@
 # 『Rによるスクレイピング入門』 第6章
+## ----chapter06 section-029 身近なオープンデータ
+
+### 横浜市のオープンデータ
+library(rvest)
+#### データ操作のためにmagrittr, dplyrを読み込む
+library(magrittr)
+library(dplyr)
+
+#### read_htmlによって「よこはまオープンデータカタログ」のページにアクセスし、HTMLを取得する
+#### html_tableでテーブルタグの内容を抽出する
+df.table <- read_html("http://www.city.yokohama.lg.jp/seisaku/seisaku/opendata/catalog.html") %>% 
+  html_table(header = TRUE) %>% 
+  extract(1) # 第一番目のtable要素の内容を取得する
+
+#### データフレーム化したテーブルの一部を表示する
+head(df.table)
+
+df.table %>% filter(grepl("区別将来人口推計", データ名))
+
+#### 区別将来人口推計(xls)
+#### http://www.city.yokohama.lg.jp/seisaku/seisaku/chousa/kihou/175/data.html
+library(rio)
+#### ファイルを読み込み、必要な列だけを選択する
+df.pop.forcast <- import("https://www.city.yokohama.lg.jp/seisaku/seisaku/chousa/kihou/175/opendata/kihou175-p15-z6.xls",
+                         skip = 5)
+
+df.pop.forcast %<>% select(Ward = `NA`, everything())
+head(df.pop.forcast)
+
+library(tidyr)
+df.pop.forcast %<>% gather(year, value, -Ward)
+head(df.pop.forcast)
+
+library(ggplot2)
+#### 日本語フォントを表示させるための設定
+quartzFonts(YuGo = quartzFont(rep("IPAexGothic", 4)))
+theme_set(theme_classic(base_size = 12, base_family = "IPAexGothic"))
+df.pop.forcast %>% 
+  ggplot(aes(year, value, group = Ward, color = Ward)) + 
+  geom_line() + 
+  xlab("年") + ylab("将来人口") + 
+  ggtitle("横浜市 区別将来人口推計")
+
+### 郵便局
+download.file(url      = "http://www.post.japanpost.jp/zipcode/dl/roman/ken_all_rome.zip",
+              destfile = "ken_all_rome.zip")
+unzip(zipfile = "ken_all_rome.zip", overwrite = TRUE)
+#### 解凍したファイルの存在を確認します
+path2file <- list.files(getwd(), pattern = ".csv$", full.names = TRUE, ignore.case = TRUE)
+path2file
+
+library(readr)
+
+df.address <- read_csv("KEN_ALL_ROME.CSV",
+                       locale = locale(encoding = "cp932"),
+                       col_names = c("郵便番号", "都道府県名", "市区町村名", "町域名", "都道府県名roman", "市区町村名roman", "町域名roman"))
+
+df.address %>% 
+  select(都道府県名, 市区町村名) %>% 
+  unique() %>% 
+  count(都道府県名, sort = TRUE)
+
 ## ----chapter06 section-030 LinkDataの活用事例
 
 ### 福井県福井市地区別人口の推移

--- a/Chapter06.R
+++ b/Chapter06.R
@@ -7,36 +7,37 @@ library(rvest)
 library(magrittr)
 library(dplyr)
 
-#### read_htmlによって「よこはまオープンデータカタログ」のページにアクセスし、HTMLを取得する
-#### html_tableでテーブルタグの内容を抽出する
-df.table <- read_html("http://www.city.yokohama.lg.jp/seisaku/seisaku/opendata/catalog.html") %>% 
-  html_table(header = TRUE) %>% 
-  extract(1) # 第一番目のtable要素の内容を取得する
 
-#### データフレーム化したテーブルの一部を表示する
-head(df.table)
+# df.table <- read_html("http://www.city.yokohama.lg.jp/seisaku/seisaku/opendata/catalog.html") %>% 
+#   html_table(header = TRUE) %>% 
+#   extract(1)
 
-df.table %>% filter(grepl("区別将来人口推計", データ名))
+# head(df.table)
+
+# df.table %>% filter(grepl("区別将来人口推計", データ名))
 
 #### 区別将来人口推計(xls)
-#### http://www.city.yokohama.lg.jp/seisaku/seisaku/chousa/kihou/175/data.html
+#### http://archive.city.yokohama.lg.jp/seisaku/seisaku/chousa/kihou/175/data.html
 library(rio)
 #### ファイルを読み込み、必要な列だけを選択する
-df.pop.forcast <- import("https://www.city.yokohama.lg.jp/seisaku/seisaku/chousa/kihou/175/opendata/kihou175-p15-z6.xls",
-                         skip = 5)
+df.pop.forecast <-
+  rio::import("http://archive.city.yokohama.lg.jp/seisaku/seisaku/chousa/kihou/175/opendata/kihou175-p15-z6.xls",
+              skip = 5,
+              range = "G6:M24") %>%
+  rename(Ward = `...1`)
 
-df.pop.forcast %<>% select(Ward = `NA`, everything())
-head(df.pop.forcast)
+# df.pop.forecast %<>% select(Ward = `NA`, everything())
+head(df.pop.forecast)
 
 library(tidyr)
-df.pop.forcast %<>% gather(year, value, -Ward)
-head(df.pop.forcast)
+df.pop.forecast %<>% gather(year, value, -Ward)
+head(df.pop.forecast)
 
 library(ggplot2)
 #### 日本語フォントを表示させるための設定
 quartzFonts(YuGo = quartzFont(rep("IPAexGothic", 4)))
 theme_set(theme_classic(base_size = 12, base_family = "IPAexGothic"))
-df.pop.forcast %>% 
+df.pop.forecast %>% 
   ggplot(aes(year, value, group = Ward, color = Ward)) + 
   geom_line() + 
   xlab("年") + ylab("将来人口") + 


### PR DESCRIPTION
6章29節 `身近なオープンデータ` のRコードが抜けていたので追加しました。また、読者より問い合わせのあった「横浜市のオープンデータ」のコードを確認しました。

本文記載の横浜市オープンデータに関する情報は、サイトリニューアルに伴うURL変更により

http://www.city.yokohama.lg.jp/seisaku/seisaku/chousa/kihou/175/data.html
から
http://archive.city.yokohama.lg.jp/seisaku/seisaku/chousa/kihou/175/data.html
に移動されました。また該当データのURLも変わっています。

URL修正の際、併せて依存パッケージの最新版を利用したコードに修正しました。（具体的にはtidyr 1.0.0へのフォローアップ）